### PR TITLE
Remove `contract` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,4 @@ std = [
     "scale-info/std",
     "psp22/std",
 ]
-contract = []
 ink-as-dependency = []

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 		--name ink-dev \
 		--volume "$(shell pwd)":/code \
 		public.ecr.aws/p6e8q1z1/ink-dev:2.1.0 \
-		cargo contract build --release --features "contract"
+		cargo contract build --release
 
 .PHONY: test
 test:
@@ -12,4 +12,4 @@ test:
 		--name ink-dev \
 		--volume "$(shell pwd)":/code \
 		public.ecr.aws/p6e8q1z1/ink-dev:2.1.0 \
-		cargo test --features "contract"
+		cargo test

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The contents of this repository has been published to [crates.io][wazero-crates]
 
 1. Add the [wrapped-azero][wazero-crates] dependency in your project's `Cargo.toml`:
 ```TOML
-wrapped-azero = { version = "1.0", default-features = false }
+wrapped-azero = { version = "1.0", default-features = false, features = ["ink-as-dependency"] }
 # ...
 [features]
 # ...

--- a/lib.rs
+++ b/lib.rs
@@ -7,7 +7,6 @@ pub use psp22::{PSP22Error, PSP22};
 
 pub use traits::{WrappedAZERO, MAINNET, TESTNET};
 
-#[cfg(feature = "contract")]
 #[ink::contract]
 mod wazero {
     use crate::WrappedAZERO;


### PR DESCRIPTION
Turns out this is not needed, as the built-in `ink-as-dependency` flag allows doing exactly the same thing as the `contract` flag was meant to.